### PR TITLE
Remove aws-sdk from dependencies

### DIFF
--- a/aws_cred_vault.gemspec
+++ b/aws_cred_vault.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "toml", "~> 0.1"
-  spec.add_dependency "aws-sdk", "~> 1.56"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The aws-sdk is never referenced in the codebase and therefore is not a
dependency.